### PR TITLE
Client의 Channel 관련 메소드 추가

### DIFF
--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -11,8 +11,6 @@ private:
 	struct sockaddr_in addr;
 	std::vector<Channel *> in_channel;
 
-	std::string password;
-	bool authorization;
 	std::string nickname;
 	std::string username;
 	std::string hostname;
@@ -29,12 +27,6 @@ public:
 
 	int	getSock(void) const;
 
-	std::string getPassword(void) const;
-	void setPassword(std::string password);
-
-	bool getAuthorization(void) const;
-	void setauthorization(bool authorization);
-
 	std::string getNickname(void) const;
 	void setNickname(std::string nickname);
 
@@ -49,6 +41,10 @@ public:
 
 	std::string getRealname(void) const;
 	void setRealname(std::string realname);
+
+	Channel* getChannel(std::string ch_name);
+	void	joinChannel(Channel *channel, std::string &password);
+	void	leaveChannel(std::string ch_name, std::string &reason);
 };
 
 #endif

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -44,7 +44,7 @@ public:
 
 	Channel* getChannel(std::string ch_name);
 	void	joinChannel(Channel *channel, std::string &password);
-	void	leaveChannel(std::string ch_name, std::string &reason);
+	void	leaveChannel(Channel *channel, std::string &reason);
 
 	class ClientException: public std::runtime_error
 	{

--- a/include/Client.hpp
+++ b/include/Client.hpp
@@ -10,7 +10,8 @@ private:
 	int	sock;
 	struct sockaddr_in addr;
 	std::vector<Channel *> in_channel;
-
+	
+	bool authorization;
 	std::string nickname;
 	std::string username;
 	std::string hostname;
@@ -22,10 +23,9 @@ public:
 	void send_to_Client(std::string msg);
 	std::string recv_from_Client(void);
 
-	void join_channel(Channel *channel);
-	void leave_channel();
-
 	int	getSock(void) const;
+	
+	bool setAuthorization(bool auth);
 
 	std::string getNickname(void) const;
 	void setNickname(std::string nickname);
@@ -45,6 +45,12 @@ public:
 	Channel* getChannel(std::string ch_name);
 	void	joinChannel(Channel *channel, std::string &password);
 	void	leaveChannel(std::string ch_name, std::string &reason);
+
+	class ClientException: public std::runtime_error
+	{
+	public:
+		ClientException(std::string err);
+	};
 };
 
 #endif

--- a/include/ft_irc.hpp
+++ b/include/ft_irc.hpp
@@ -4,6 +4,7 @@
 # include <iostream>
 # include <stdexcept>
 # include <unistd.h>
+# include <fcntl.h>
 # include <poll.h>
 # include <vector>
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -127,7 +127,7 @@ void	Client::joinChannel(Channel *channel, std::string &password)
 	in_channel.push_back(channel);
 }
 
-void	Client::leaveChannel(std::string ch_name, std::string &reason)
+void	Client::leaveChannel(Channel *channel, std::string &reason)
 {
 	if (!authorization)
 		return ;
@@ -135,13 +135,13 @@ void	Client::leaveChannel(std::string ch_name, std::string &reason)
 	std::vector<Channel*>::iterator it;
 	for (it = in_channel.begin(); it != in_channel.end(); it++)
 	{
-		if ((*it)->getName() == ch_name)
+		if ((*it) == channel)
 			break;
 	}
 	if (it == in_channel.end())
 	{
 		send_to_Client("일치하는 채널 없음");
-		return;
+		throw ClientException("일치하는 채널 없음")
 	}
 	(*it)->sub_client(this, reason);
 	in_channel.erase(it);

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -40,26 +40,6 @@ int	Client::getSock(void) const
 	return sock;
 }
 
-std::string Client::getPassword(void) const
-{
-	return password;
-}
-
-void Client::setPassword(std::string password)
-{
-	this->password = password;
-}
-
-bool Client::getAuthorization(void) const
-{
-	return authorization;
-}
-
-void Client::setauthorization(bool authorization)
-{
-	this->authorization = authorization;
-}
-
 std::string Client::getNickname(void) const
 {
 	return nickname;
@@ -108,4 +88,45 @@ std::string Client::getRealname(void) const
 void Client::setRealname(std::string realname)
 {
 	this->realname = realname;
+}
+
+Channel* Client::getChannel(std::string ch_name)
+{
+	std::vector<Channel*>::iterator it;
+
+	for (it = in_channel.begin(); it != in_channel.end(); it++)
+	{
+		if ((*it)->getName() == ch_name)
+			return (*it);
+	}
+	return (NULL);
+}
+
+void	Client::joinChannel(Channel *channel, std::string &password)
+{
+	bool success = channel->add_client(this, password);
+	if (!success)
+	{
+		send_to_Client("[fail to join]");
+		return;	
+	}
+	in_channel.push_back(channel);
+}
+
+void	Client::leaveChannel(std::string ch_name, std::string &reason)
+{
+	std::vector<Channel*>::iterator it;
+
+	for (it = in_channel.begin(); it != in_channel.end(); it++)
+	{
+		if ((*it)->getName() == ch_name)
+			break;
+	}
+	if (it == in_channel.end())
+	{
+		send_to_Client("일치하는 채널 없음");
+		return;
+	}
+	(*it)->sub_client(this, reason);
+	in_channel.erase(it);
 }


### PR DESCRIPTION
1. getChannel: 클라이언트가 참여하고 있는 채널들 중 이름이 일치하는 채널을 찾아 리턴
2. joinChannel: 채널에 참가 -> channel.addClient() 호출
3. leaveChannel: 채널 떠남 -> channel.subClient() 호출 
4. password, authorization 변수 및 관련 메소드 삭제