### PR TITLE
Feature/#8 channel 객체 만들기

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -19,7 +19,7 @@ private:
 	void addClient(Client *client, ClientMode *mode);
 	void broadcast(const std::string &msg);
 	void broadcast(Client *client, const std::string &msg);
-	ClientMode* find_client(std::string nickname);
+	ClientMode* findClient(std::string nickname);
 
 public:
 	Channel(Client *client, std::string name, std::string spassword);

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -1,50 +1,46 @@
-#include <vector>
-#include <iostream>
-#include <Client.hpp>
+#ifndef CHANNEL_HPP
+# define CHANNEL_HPP
 
-#define MODE_I 0x01
-#define MODE_T 0x02
-#define MODE_K 0x04
-#define MODE_O 0x08
-#define MODE_L 0x10
+#include "ft_irc.hpp"
+
+//#define MODE_I 0x01
+//#define MODE_T 0x02
+//#define MODE_K 0x04
+//#define MODE_O 0x08
+//#define MODE_L 0x10
 
 class Client;
-class Server;
+class ClientMode;
+class ChannelMode;
 
 class Channel
 {
 private:
-	Server	*server;
+	std::map<Client*, ClientMode*> client_map;
+	ChannelMode	*mode;
 	std::string	name;
-	std::string topic;
-	unsigned int mode;
+	std::string ch_topic;
 	std::string	password;
-	std::vector<Client *> clients;
-	Client *channel_operator;
+
+	void addClient(Client *client, std::string &password);
+	void broadcast(Client *client, const std::string &msg);
 public:
-	Channel(Server* server, Client *client, std::string &name, std::string &password);
-	void add_channel(Client *client, std::string &password);
-	void sub_channel(Client *client, std::string &reason);
+	Channel(Client *client, std::string name, std::string password);
 
-	//<channel> <user> [<comment>(==reason)]
-	void kick(Client *client, std::string &username, std::string &comments);
-	//<nickname> <channel>
-	void invite(Client *client, std::string &nickname);
-	//<channel> [<topic>]
-	void change_topic(Client *client, std::string &topic);
-	//<channel> {[+|-]|o|p|s|i|t|n|b|v} [<limit>] [<user>] [<ban mask>]
-	void change_mode(Client *client, std::string &mode);
+	void subClient(Client *client, std::string &reason);
 
-	std::string getName(void) const;
-	void setName(std::string name);
+	void	invite(Client *oper, Client *invitee);
+	void	part(Client* client);
+	void	kick(Client *oper, Client *kicked, std::string &comments);
+	void	topic(Client *client, std::string &topic);
+	void	mode(Client *oper, std::string &mode);
+	void	privmsg(Client *client, std::string &msg);
+
+	std::string	getName(void) const;
+	void	setName(std::string name);
 
 	std::string getToic(void) const;
-	
-	void broadcast(Client *client, const std::string &msg);
-	
-	class ChannelException: public std::runtime_error
-	{
-	public:
-		ChannelException(std::string err);
-	};
+	int	getClientSize();
 };
+
+#endif

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -11,24 +11,27 @@ class Channel
 {
 private:
 	std::map<Client*, ClientMode*> client_map;
-	ChannelMode	*mode;
+	unsigned int	*ch_mode;
 	std::string	name;
 	std::string ch_topic;
 	std::string	password;
+	int	join_cnt;
+	int	limit = 0;
 
 	void addClient(Client *client, ClientMode *mode);
-	void broadcast(std::string &msg);
-	void broadcast(Client *client, std::string msg);
+	void broadcast(const std::string &msg);
+	void broadcast(Client *client, const std::string &msg);
+
 public:
 	Channel(Client *client, std::string name, std::string spassword);
 
 	void	invite(Client *oper, Client *invitee);
 	void	join(Client *client, std::string &password);
-	void	part(Client* client); //reason?
+	void	part(Client* client);
 	void	kick(Client *oper, Client *kicked, std::string &comments);
 	void	topic(Client *client, std::string &topic);
-	void	mode(Client *oper, std::string &mode);
-	void	privmsg(Client *client, std::string &msg);
+	void	mode(Client *oper, std::vector<std::string>mode_str);
+	void	privmsg(Client *client, const std::string &msg);
 
 	void subClient(Client *client);
 
@@ -37,6 +40,8 @@ public:
 
 	std::string getToic(void) const;
 	int	getClientSize();
+
+	std::string getClientNameList(void) const;
 };
 
 #endif

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -3,12 +3,6 @@
 
 #include "ft_irc.hpp"
 
-//#define MODE_I 0x01
-//#define MODE_T 0x02
-//#define MODE_K 0x04
-//#define MODE_O 0x08
-//#define MODE_L 0x10
-
 class Client;
 class ClientMode;
 class ChannelMode;
@@ -22,19 +16,21 @@ private:
 	std::string ch_topic;
 	std::string	password;
 
-	void addClient(Client *client, std::string &password);
-	void broadcast(Client *client, const std::string &msg);
+	void addClient(Client *client, ClientMode *mode);
+	void broadcast(std::string &msg);
+	void broadcast(Client *client, std::string msg);
 public:
-	Channel(Client *client, std::string name, std::string password);
-
-	void subClient(Client *client, std::string &reason);
+	Channel(Client *client, std::string name, std::string spassword);
 
 	void	invite(Client *oper, Client *invitee);
-	void	part(Client* client);
+	void	join(Client *client, std::string &password);
+	void	part(Client* client); //reason?
 	void	kick(Client *oper, Client *kicked, std::string &comments);
 	void	topic(Client *client, std::string &topic);
 	void	mode(Client *oper, std::string &mode);
 	void	privmsg(Client *client, std::string &msg);
+
+	void subClient(Client *client);
 
 	std::string	getName(void) const;
 	void	setName(std::string name);

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -11,16 +11,15 @@ class Channel
 {
 private:
 	std::map<Client*, ClientMode*> client_map;
-	unsigned int	*ch_mode;
+	ChannelMode	*ch_mode;
 	std::string	name;
 	std::string ch_topic;
-	std::string	password;
 	int	client_size;
-	int	limit = 0;
 
 	void addClient(Client *client, ClientMode *mode);
 	void broadcast(const std::string &msg);
 	void broadcast(Client *client, const std::string &msg);
+	ClientMode* find_client(std::string nickname);
 
 public:
 	Channel(Client *client, std::string name, std::string spassword);
@@ -30,10 +29,11 @@ public:
 	void	part(Client* client);
 	void	kick(Client *oper, Client *kicked, std::string &comments);
 	void	topic(Client *client, std::string &topic);
-	void	mode(Client *oper, std::vector<std::string>mode_str);
+	void	mode(Client *oper, std::vector<std::string>mode_vect);
 	void	privmsg(Client *client, const std::string &msg);
 
-	void subClient(Client *client);
+	void	changeOper(std::string nickname, bool oper);
+	void	subClient(Client *client);
 
 	std::string	getName(void) const;
 	void	setName(std::string name);

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -23,8 +23,8 @@ private:
 	Client *channel_operator;
 public:
 	Channel(Server* server, Client *client, std::string &name, std::string &password);
-	void join_channel(Client *client, std::string &password);
-	void leave_channel(Client *client, std::string &reason);
+	void add_channel(Client *client, std::string &password);
+	void sub_channel(Client *client, std::string &reason);
 
 	//<channel> <user> [<comment>(==reason)]
 	void kick(Client *client, std::string &username, std::string &comments);
@@ -38,5 +38,13 @@ public:
 	std::string getName(void) const;
 	void setName(std::string name);
 
+	std::string getToic(void) const;
+	
 	void broadcast(Client *client, const std::string &msg);
+	
+	class ChannelException: public std::runtime_error
+	{
+	public:
+		ChannelException(std::string err);
+	};
 };

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -15,7 +15,7 @@ private:
 	std::string	name;
 	std::string ch_topic;
 	std::string	password;
-	int	join_cnt;
+	int	client_size;
 	int	limit = 0;
 
 	void addClient(Client *client, ClientMode *mode);

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -23,6 +23,7 @@ private:
 
 public:
 	Channel(Client *client, std::string name, std::string spassword);
+	~Channel();
 
 	void	invite(Client *oper, Client *invitee);
 	void	join(Client *client, std::string &password);

--- a/include/ft_irc.hpp
+++ b/include/ft_irc.hpp
@@ -7,6 +7,7 @@
 # include <fcntl.h>
 # include <poll.h>
 # include <vector>
+# include <map>
 
 # include <sys/types.h>
 # include <sys/socket.h>

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,12 +1,17 @@
 #include "Channel.hpp"
 
-Channel::Channel(Client *client, std::string name, std::string password)
+Channel::Channel(Client *client, std::string name, std::string password = "")
 {
-	client_map[client] = new ClientMode(ClientMode::OPERATE || ClientMode::JOINED); //operator & join
-	mode = new ChannelMode();
+	if (name.at(0) != '@')
+		throw IRCException("476 " + client->getNickname() +" "+ name + " :Invalid channel name");
 	this->name = name;
+	client_map[client] = new ClientMode(ClientMode::OPERATE || ClientMode::JOINED); //operator & join
+	ch_mode = new ChannelMode();
 	ch_topic = "";
 	this->password = password;
+	join_cnt = 1;
+
+	client->send_to_Client(client->getPrefix() + "JOIN :" + name);
 }
 
 void Channel::addClient(Client *client, ClientMode *mode)
@@ -22,6 +27,9 @@ void Channel::subClient(Client *client)
 	if (it == client_map.end())
 		throw IRCException("cannot erase");
 	client_map.erase(it);
+	join_cnt--;
+	if (join_cnt == 0)
+		throw IRCException("delete this channel");
 }
 
 void Channel::broadcast(const std::string &msg)
@@ -29,7 +37,7 @@ void Channel::broadcast(const std::string &msg)
 	std::map<Client*, ClientMode*>::iterator it;
 	for (it = client_map.begin(); it != client_map.end(); it++)
 	{
-		if (!it->first->isJoined())
+		if (it->first->isJoined() == false)
 			continue;
 		it->first->send_to_Client(msg);
 	}
@@ -48,33 +56,36 @@ void Channel::broadcast(Client *client, const std::string &msg)
 
 void	Channel::invite(Client *oper, Client *invitee)
 {
-	if (client_map[oper]->isOper())
-		throw IRCException("is not operator");
 	if (client_map[invitee]->isJoin())
-		throw IRCException("is already joined");
+		throw IRCException(":is already on channel");
+	if (ch_mode->isInvited() && !client_map[oper]->isOper())
+		throw IRCException(":You must be a channel half-operator");
 	addClient(invitee, new ClientMode(ClientMode::INVITED));
-	invitee->send_to_Client("invite this channel");
+	invitee->send_to_Client(oper->getPrefix() + "INVITE");
 }
 
 void	Channel::join(Client *client, std::string &password)
 {
 	ClientMode *found = client_map[client];
 	//invite mode check
-	if (!(mode->isInvited() && found && found->isInvited()))
-		throw IRCException("invite mode && not invited");
+	if (!(ch_mode->isInvited() && found && found->isInvited()))
+		throw IRCException(":Cannot join channel (invite only)");
 	//already exist
 	if (found->isJoined())
-		throw IRCException("already existed");
-	//password mode check
-		//password check
-	if (mode->isPassword() && this->password == password)
-		throw IRCException("incorrect PW");
+		throw IRCException("already existed: no reply");
+	//password check
+	if (ch_mode->isPassword() && this->password != password)
+		throw IRCException(" :Cannot join channel (incorrect channel key)");
+	//limit check
+	if (ch_mode->isLimit() && join_cnt > limit)
+		throw IRCException(":Cannot join channel (channel is full)");
 
 	if (found)
-		found.setMode(JOIN);
+		found.setMode(ClientMode::JOIN);
 	else
 		addClient(client, new ClientMode(ClientMode::JOIN));
-	broadcast(client, "[join the new user]");
+	join_cnt++;
+	broadcast("JOIN :" + name);
 }
 
 void	Channel::part(Client* client)
@@ -83,47 +94,143 @@ void	Channel::part(Client* client)
 
 	it = client_map.find(client);
 	if (it == client_map.end() || it->second->isJoined() == false)
-		throw IRCException("you are not joind");
+		throw IRCException("You're not on that channel");
 	client_map.erase(it);
-	client->send_to_Client("part");
-	broadcast(client, "part");
+	join_cnt--;
+	broadcast("PART :" + name);
 }
 
 void Channel::kick(Client *oper, Client *kicked, std::string &comments)
 {
 	if (client_map[oper]->isOperate())
-		throw IRCException("is not operator");
+		throw IRCException(":You must be a channel half-operator");
 	if (!client_map[kicked]->isJoined())
-		throw IRCException("not join client");
+		throw IRCException(":They are not on that channel");
 	client_map.erase(client_map.find(kicked));
-	kicked->send_to_Client("you are kicked");
-	broadcast(kicked, "kick user");
+	join_cnt--;
+	broadcast("KICK:" + comments);
 }
 
+//수정 요함
 void Channel::topic(Client *client, std::string &topic)
 {
+	if (topic.empty())
+	{
+		if (ch_topic.empty())
+			client->send_to_Client(name + ":No topic is set.");
+		else
+			client->send_to_Client(name + ":" + ch_topic);
+		return ;
+	}
 	if (mode->isTopic() && !client_map[client]->isOperate())
-		throw IRCException("need operator priviliged");
+		throw IRCException(":You must be a channel half-operator");
 	this->ch_topic = topic;
-	broadcast("topic changed");
+	broadcast("332: " + ch_topic);
 }
 
-//std::string mode_str = "itkol";
-void Channel::mode(Client *client, std::string &mode_str)
+void Channel::mode(Client *client, std::vector<std::string> mode_str)
 {
-	if (!client->isOperate())
-		throw IRCException("need operator priviliged");
-	
-	unsigned int mode_value = mode->getMode();
-	char	op = '+';
-	std::string::iterator it = mode_str.begin();
-	if (*it == '+' || *it == '-')
-			op = *it;
-	if (std::string::iterator it = mode_str.begin(); it != mode_str.end(); it++)
+	if (mode_str.empty())
 	{
-		
-		
+		client->send_to_Client("324" + ch_mode.toString());
+		return ;
 	}
+	if (!client->isOperate())
+		throw IRCException("482" + client->getNickname() +" "+ name + ":You must have channel halfop access or above to set channel mode " + mode_str[0]);
+	if (!ChannelMode::isValidMode(mode_str[0]))
+		throw IRCException("is not valid mode");
+	ChannelMode::changeMode(mode_str[0], ch_mode);
+	
+	std::string::iterator it = mode_str[0].begin();
+	char op = '+';
+	if (*it == '-')
+		op = '-';
+	for (int idx = 1; it != mode_str[0].end(); it++)
+	{
+		switch (*it)
+		{
+			case 'i':
+			case 't':
+				break;
+			case 'l':
+				if (op == '+')
+				{
+					try
+					{
+						limit = mode_str[idx++];
+					}
+					catch(const std::exception& e)
+					{
+						throw IRCException("인자 부족");
+					}
+					
+				}
+				else
+					limit = 0;
+				break;
+			case 'k':
+				if (op == '+')
+				{
+					if (!password.empty())
+						throw IRCException("already password existed: no reply");
+					try
+					{
+						password = mode_str[idx++];
+					}
+					catch(const std::exception& e)
+					{
+						throw IRCException(":You must specify a parameter for the key mode. Syntax: <key>.");
+					}
+					break;
+				}
+				else
+				{
+					try
+					{
+						if (password == mode_str[idx++])
+						{
+							password = "";
+							client->send_to_Client("MODE" + name + "-k :" + password);
+						}
+						else
+							client->send_to_Client("467 :Channel key already set")
+					}
+					catch(const std::exception& e)
+					{
+						throw IRCException("인자부족: no reply");
+					}
+					break;
+				}
+			case 'o':
+			{
+				try
+				{
+					Client *c = getClient(mode_str[idx++]);
+					if (!c)
+						throw IRCException("클라이언트 없음 :no _reply");
+				}
+				catch(const std::exception& e)
+				{
+					throw IRCException("인자 없음 -> 메시지 확인해볼 것");
+				}
+				if (op == '+')
+				{
+						
+				}
+				else
+				{
+
+				}
+			}
+			default:
+				;
+		}
+	}
+}
+
+void Channel::privmsg(Client *client, const std::string &msg)
+{
+	broadcast(client, ("PRIVMSG " + name + ": " + msg));
 }
 
 std::string Channel::getName(void) const
@@ -143,13 +250,20 @@ std::string Channel::getToic(void) const
 
 int	Channel::getClientSize()
 {
-	std::map<Client*, ClientMode*>::iterator it;
+	return join_cnt;
+}
 
-	int	cnt = 0;
-	for(it = client_map.begin(); it != client_map.end(); it++)
+std::string Channel::getClientNameList(void) const
+{
+	std::map<Client*, ClientMode*>::iterator it;
+	std::string ret = ":";
+	for (it = client_map.begin(); it != client_map.end(); it++)
 	{
-		if (it->second->isJoined())
-			cnt++;
+		if (!it->second->isJoin())
+			continue ;
+		if (!it->second->isOperator())
+			ret += "@";
+		ret += it->first->getNickname() + " ";
 	}
-	return cnt;
+	return ret;
 }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -51,7 +51,7 @@ void Channel::broadcast(Client *client, const std::string &msg)
 	}
 }
 
-ClientMode* Channel::find_client(std::string nickname)
+ClientMode* Channel::findClient(std::string nickname)
 {
 	std::map<Client*, ClientMode*>::iterator it;
 	for (it = client_map.begin(); it != client_map.end(); it++)
@@ -151,7 +151,7 @@ void Channel::privmsg(Client *client, const std::string &msg)
 
 void	Channel::changeOper(std::string nickname, bool oper)
 {
-	ClientMode* found = find_client(nickname);
+	ClientMode* found = findClient(nickname);
 	if (!found || !found->isJoined())
 		throw IRCException("???"); //MODE -o 에서 해당클라이언트가 챈러에 없는 경우
 	if (oper)

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -27,8 +27,6 @@ void Channel::subClient(Client *client)
 		throw IRCException("cannot erase");
 	client_map.erase(it);
 	client_size--;
-	if (client_size == 0)
-		throw IRCException("delete this channel");
 }
 
 void Channel::broadcast(const std::string &msg)
@@ -136,60 +134,61 @@ void Channel::mode(Client *client, std::vector<std::string> mode_str)
 		throw IRCException("is not valid mode");
 	ChannelMode::changeMode(mode_str[0], ch_mode);
 	
-	std::string::iterator it = mode_str[0].begin();
-	char op = '+';
-	if (*it == '-')
-		op = '-';
-	for (int idx = 1; it != mode_str[0].end(); it++)
-	{
-		switch (*it)
-		{
-			case 'l':
-			{
-				if (op == '+')
-					limit = stoi(mode_str[idx++]); //stoi 11함수
-				else
-					limit = 0;
-				break;
-			}
-			case 'k':
-			{
-				if (op == '+')
-				{
-					if (!password.empty())
-						throw IRCException("already password existed: no reply");
-						password = mode_str[idx++];
-				}
-				else
-				{
-					if (password == mode_str[idx++])
-					{
-						password = "";
-						client->send_to_Client("MODE" + name + "-k :" + password);
-					}
-					else
-						client->send_to_Client("467 :Channel key already set");
-					break;
+	// ChannelMode로 보닐 것들
+	// std::string::iterator it = mode_str[0].begin();
+	// char op = '+';
+	// if (*it == '-')
+	// 	op = '-';
+	// for (int idx = 1; it != mode_str[0].end(); it++)
+	// {
+	// 	switch (*it)
+	// 	{
+	// 		case 'l':
+	// 		{
+	// 			if (op == '+')
+	// 				limit = stoi(mode_str[idx++]); //stoi 11함수
+	// 			else
+	// 				limit = 0;
+	// 			break;
+	// 		}
+	// 		case 'k':
+	// 		{
+	// 			if (op == '+')
+	// 			{
+	// 				if (!password.empty())
+	// 					throw IRCException("already password existed: no reply");
+	// 					password = mode_str[idx++];
+	// 			}
+	// 			else
+	// 			{
+	// 				if (password == mode_str[idx++])
+	// 				{
+	// 					password = "";
+	// 					client->send_to_Client("MODE" + name + "-k :" + password);
+	// 				}
+	// 				else
+	// 					client->send_to_Client("467 :Channel key already set");
+	// 				break;
 
-			}
-			case 'o':
-			{
-				ClientMode *c = getClient(mode_str[idx++]);
-				if (!c)
-					throw IRCException("클라이언트 없음 :no _reply");
-				if (op == '+')
-				{
-					if (!c->isJoined())
-						throw IRCException("조인하지 않은 클라이언트: ???");
-					c->setClientMode(ClientMode::OPERATE);
-				}
-				else
-				{
-					;//
-				}
-			}
-		}
-	}
+	// 		}
+	// 		case 'o':
+	// 		{
+	// 			ClientMode *c = getClient(mode_str[idx++]);
+	// 			if (!c)
+	// 				throw IRCException("클라이언트 없음 :no _reply");
+	// 			if (op == '+')
+	// 			{
+	// 				if (!c->isJoined())
+	// 					throw IRCException("조인하지 않은 클라이언트: ???");
+	// 				c->setClientMode(ClientMode::OPERATE);
+	// 			}
+	// 			else
+	// 			{
+	// 				;//
+	// 			}
+	// 		}
+		// }
+	// }
 }
 
 void Channel::privmsg(Client *client, const std::string &msg)

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -11,7 +11,7 @@ Channel::Channel(Server* server, Client *client, std::string &name, std::string 
 	channel_operator = client;
 }
 
-void Channel::join_channel(Client *client, std::string &password)
+void Channel::add_channel(Client *client, std::string &password)
 {
 	if (this->password != password)
 	{
@@ -22,7 +22,7 @@ void Channel::join_channel(Client *client, std::string &password)
 	broadcast(client, "[join the new user]");
 }
 
-void Channel::leave_channel(Client *client, std::string &reason)
+void Channel::sub_channel(Client *client, std::string &reason)
 {
 	std::vector<Client*>::iterator it = clients.begin();
 	for (; it != clients.end(); it++)
@@ -37,6 +37,8 @@ void Channel::leave_channel(Client *client, std::string &reason)
 	}
 	broadcast((*it), "[leave the user]" + reason);
 	clients.erase(it);
+	//if (clients.empty())
+	//	throw ChannelException("채널에 유저 없음");
 }
 
 void Channel::kick(Client *client, std::string &username, std::string &comments)
@@ -69,6 +71,11 @@ void Channel::invite(Client *client, std::string &nickname)
 		client->send_to_Client("not channel operator");
 		return;
 	}
+	if (mode & MODE_I == 0)
+	{
+		client->send_to_Client("not invite mode");
+		return;
+	}
 	Client *invitee = server->getClient(nickname);
 	if (invitee == NULL)
 	{
@@ -85,7 +92,7 @@ void Channel::change_topic(Client *client, std::string &topic)
 		client->send_to_Client("not channel operator");
 		return;
 	}
-	this->topic == topic;
+	this->topic = topic;
 	broadcast(client, "topic changed");
 }
 
@@ -146,6 +153,10 @@ void Channel::setName(std::string name)
 	this->name = name;
 }
 
+std::string Channel::getToic(void) const
+{
+	return topic;
+}
 void Channel::broadcast(Client *client, const std::string &msg)
 {
 	for (std::vector<Client*>::iterator it = clients.begin(); it != clients.end(); it++)
@@ -155,3 +166,5 @@ void Channel::broadcast(Client *client, const std::string &msg)
 		(*it)->send_to_Client(msg);
 	}
 }
+
+Channel::ChannelException::ChannelException(std::string err):runtime_error(err){};

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -154,7 +154,10 @@ void	Channel::changeOper(std::string nickname, bool oper)
 	ClientMode* found = find_client(nickname);
 	if (!found || !found->isJoined())
 		throw IRCException("???"); //MODE -o 에서 해당클라이언트가 챈러에 없는 경우
-	found->setMode(ClientMode::JOIN);
+	if (oper)
+		found->setMode(ClientMode::JOIN);
+	else
+		found->setMode(~ClientMode::JOIN);
 }
 
 std::string Channel::getName(void) const


### PR DESCRIPTION
freenode & limechat 기준 참고하여 작성.

`일단 참고용으로 풀리퀘합니다!`

### 슬랙 내용 외 추가된 내용
1. client_size: MODE +l 에 대한 내용, 현재 채널 접속 인원 수 저장
2. limit: MODE +l 에 대한 내용, 채널 최대 동시 접속 인원수 저장
3. broadcast 오버로딩: 인자에 client O -> 해당 클라이언트 제외 브로드캐스팅, X -> 모든 클라이언트에게 브로드캐스팅
4. getClientNameList(): 채널 JOIN 시 서버에서 클라이언트에게 해당 채널 참여 클라이언트 닉네임리스트 전송해준다.

### 생각해본 것들
1. ChannelMode::isValidMode함수에서 vector 개수 계산 함께 해주어야 할 듯...
2. 각 전송되는 메시지 앞 prefix: 보내는 서버나 클라이언트의 정보 담김 -> Server, Client class 안에 getPrefix() 구현되어야함.
3. mode() 함수 더 예쁘게 짜고 싶다...